### PR TITLE
feat: manifest loader, schema validation, CLI validate command

### DIFF
--- a/src/crimp/cli.py
+++ b/src/crimp/cli.py
@@ -1,7 +1,16 @@
 """Crimp CLI entry point."""
 
+import json
+from pathlib import Path
+
 import click
+from rich.console import Console
+from rich.table import Table
+
 from crimp import __version__
+from crimp.manifest import ManifestError, load
+
+console = Console()
 
 
 @click.group()
@@ -19,20 +28,48 @@ def cli():
 @click.option("--dry-run", is_flag=True, help="List outputs without writing files.")
 def build(manifest, output, dry_run):
     """Generate all outputs from a manifest file."""
-    click.echo("build: not yet implemented")
+    try:
+        m = load(manifest)
+    except ManifestError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+
+    console.print(f"[green]✓[/green] Manifest valid: [bold]{m.project.name}[/bold] (crimp {m.crimp_version})")
+    console.print(f"  {len(m.components)} components, {len(m.connections)} connections")
+    console.print()
+    console.print("[yellow]build: generators not yet implemented[/yellow]")
 
 
 @cli.command()
 @click.argument("manifest", type=click.Path(exists=True))
 def validate(manifest):
     """Validate a manifest file against the Crimp schema."""
-    click.echo("validate: not yet implemented")
+    try:
+        m = load(manifest)
+    except ManifestError as e:
+        console.print(f"[red]✗ Invalid:[/red] {e}")
+        raise SystemExit(1)
+
+    console.print(f"[green]✓ Valid:[/green] [bold]{m.project.name}[/bold]")
+    console.print(f"  crimp_version : {m.crimp_version}")
+    console.print(f"  components    : {len(m.components)}")
+    console.print(f"  connections   : {len(m.connections)}")
+    console.print(f"  wire_standards: {len(m.wire_standards)}")
+    console.print(f"  power_rails   : {len(m.power_rails)}")
+
+    if m.components:
+        table = Table(title="Components", show_lines=False)
+        table.add_column("ID")
+        table.add_column("Name")
+        table.add_column("Type")
+        table.add_column("Pins")
+        for comp_id, comp in m.components.items():
+            table.add_row(comp_id, comp.name, comp.type, str(len(comp.pins)))
+        console.print(table)
 
 
 @cli.command()
 def schema():
     """Print the Crimp manifest JSON schema (useful for prompting an AI)."""
-    import json
-    from pathlib import Path
-    schema_path = Path(__file__).parent.parent.parent / "schema" / "manifest.schema.json"
-    click.echo(json.dumps(json.loads(schema_path.read_text()), indent=2))
+    from crimp.manifest import SCHEMA_PATH
+    console.print(json.dumps(json.loads(SCHEMA_PATH.read_text()), indent=2))

--- a/src/crimp/manifest.py
+++ b/src/crimp/manifest.py
@@ -1,0 +1,313 @@
+"""Manifest loading and validation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+SCHEMA_PATH = Path(__file__).parent.parent.parent / "schema" / "manifest.schema.json"
+
+
+# ---------------------------------------------------------------------------
+# Typed model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Pin:
+    id: str
+    function: str
+    signal_type: str
+    direction: str
+    physical_label: str = ""
+    voltage_rail: str = ""
+    notes: str = ""
+
+
+@dataclass
+class ConnectorSpec:
+    type: str = ""
+    position: str = "none"
+    pin_order: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Component:
+    id: str
+    name: str
+    type: str
+    pins: dict[str, Pin] = field(default_factory=dict)
+    description: str = ""
+    datasheet_url: str = ""
+    voltage_logic: float | None = None
+    connector: ConnectorSpec | None = None
+    notes: str = ""
+
+
+@dataclass
+class WireSpec:
+    ref: str = ""
+    gauge_awg: int | None = None
+    color: str = ""
+    length_mm: int | None = None
+    notes: str = ""
+
+
+@dataclass
+class ConnectionEndpoint:
+    component: str
+    pin: str
+
+
+@dataclass
+class CommissioningSpec:
+    test_method: str = "none"
+    expected_value: Any = None
+    tolerance: Any = None
+    instrument: str = "none"
+    notes: str = ""
+
+
+@dataclass
+class Connection:
+    id: str
+    from_: ConnectionEndpoint
+    to: ConnectionEndpoint
+    wire: WireSpec
+    label: str = ""
+    assembly_order: int = 9999
+    commissioning: CommissioningSpec = field(default_factory=CommissioningSpec)
+    notes: str = ""
+
+
+@dataclass
+class PowerRail:
+    id: str
+    voltage_nominal: float
+    source_component: str = ""
+    max_current_a: float | None = None
+    notes: str = ""
+
+
+@dataclass
+class WireStandard:
+    id: str
+    gauge_awg: int
+    color: str
+    notes: str = ""
+
+
+@dataclass
+class BomOverride:
+    description: str
+    qty: int
+    unit: str = ""
+    source_notes: str = ""
+
+
+@dataclass
+class Project:
+    name: str
+    description: str
+    revision: str = ""
+    notes: str = ""
+
+
+@dataclass
+class Manifest:
+    crimp_version: str
+    project: Project
+    components: dict[str, Component]
+    connections: list[Connection]
+    wire_standards: dict[str, WireStandard] = field(default_factory=dict)
+    power_rails: dict[str, PowerRail] = field(default_factory=dict)
+    bom_overrides: list[BomOverride] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Loading and validation
+# ---------------------------------------------------------------------------
+
+
+class ManifestError(Exception):
+    """Raised when a manifest cannot be loaded or validated."""
+
+
+def _load_schema() -> dict:
+    if not SCHEMA_PATH.exists():
+        raise ManifestError(f"Schema not found at {SCHEMA_PATH}")
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def validate_raw(data: dict) -> None:
+    """Validate a raw manifest dict against the JSON schema.
+
+    Raises ManifestError with a human-readable message on failure.
+    """
+    schema = _load_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+    if errors:
+        messages = []
+        for err in errors:
+            path = " → ".join(str(p) for p in err.path) or "(root)"
+            messages.append(f"  {path}: {err.message}")
+        raise ManifestError("Manifest validation failed:\n" + "\n".join(messages))
+
+
+def _parse(data: dict) -> Manifest:
+    """Convert a validated raw manifest dict into a typed Manifest."""
+
+    project = Project(
+        name=data["project"]["name"],
+        description=data["project"]["description"],
+        revision=data["project"].get("revision", ""),
+        notes=data["project"].get("notes", ""),
+    )
+
+    wire_standards = {
+        k: WireStandard(
+            id=k,
+            gauge_awg=v["gauge_awg"],
+            color=v["color"],
+            notes=v.get("notes", ""),
+        )
+        for k, v in data.get("wire_standards", {}).items()
+    }
+
+    power_rails = {
+        k: PowerRail(
+            id=k,
+            voltage_nominal=v["voltage_nominal"],
+            source_component=v.get("source_component", ""),
+            max_current_a=v.get("max_current_a"),
+            notes=v.get("notes", ""),
+        )
+        for k, v in data.get("power_rails", {}).items()
+    }
+
+    components: dict[str, Component] = {}
+    for comp_id, comp_data in data["components"].items():
+        pins = {
+            pin_id: Pin(
+                id=pin_id,
+                function=pin_data["function"],
+                signal_type=pin_data["signal_type"],
+                direction=pin_data["direction"],
+                physical_label=pin_data.get("physical_label", ""),
+                voltage_rail=pin_data.get("voltage_rail", ""),
+                notes=pin_data.get("notes", ""),
+            )
+            for pin_id, pin_data in comp_data["pins"].items()
+        }
+        conn_data = comp_data.get("connector")
+        connector = (
+            ConnectorSpec(
+                type=conn_data.get("type", ""),
+                position=conn_data.get("position", "none"),
+                pin_order=conn_data.get("pin_order", []),
+            )
+            if conn_data
+            else None
+        )
+        components[comp_id] = Component(
+            id=comp_id,
+            name=comp_data["name"],
+            type=comp_data["type"],
+            pins=pins,
+            description=comp_data.get("description", ""),
+            datasheet_url=comp_data.get("datasheet_url", ""),
+            voltage_logic=comp_data.get("voltage_logic"),
+            connector=connector,
+            notes=comp_data.get("notes", ""),
+        )
+
+    connections: list[Connection] = []
+    for conn_data in data["connections"]:
+        c_spec = conn_data.get("commissioning", {})
+        wire_data = conn_data["wire"]
+
+        # Resolve wire standard ref if present
+        ref = wire_data.get("ref", "")
+        if ref and ref in wire_standards:
+            std = wire_standards[ref]
+            gauge = wire_data.get("gauge_awg", std.gauge_awg)
+            color = wire_data.get("color", std.color)
+        else:
+            gauge = wire_data.get("gauge_awg")
+            color = wire_data.get("color", "")
+
+        connections.append(
+            Connection(
+                id=conn_data["id"],
+                label=conn_data.get("label", ""),
+                from_=ConnectionEndpoint(
+                    component=conn_data["from"]["component"],
+                    pin=conn_data["from"]["pin"],
+                ),
+                to=ConnectionEndpoint(
+                    component=conn_data["to"]["component"],
+                    pin=conn_data["to"]["pin"],
+                ),
+                wire=WireSpec(
+                    ref=ref,
+                    gauge_awg=gauge,
+                    color=color,
+                    length_mm=wire_data.get("length_mm"),
+                    notes=wire_data.get("notes", ""),
+                ),
+                assembly_order=conn_data.get("assembly_order", 9999),
+                commissioning=CommissioningSpec(
+                    test_method=c_spec.get("test_method", "none"),
+                    expected_value=c_spec.get("expected_value"),
+                    tolerance=c_spec.get("tolerance"),
+                    instrument=c_spec.get("instrument", "none"),
+                    notes=c_spec.get("notes", ""),
+                ),
+                notes=conn_data.get("notes", ""),
+            )
+        )
+
+    # Sort by assembly_order
+    connections.sort(key=lambda c: c.assembly_order)
+
+    bom_overrides = [
+        BomOverride(
+            description=b["description"],
+            qty=b["qty"],
+            unit=b.get("unit", ""),
+            source_notes=b.get("source_notes", ""),
+        )
+        for b in data.get("bom_overrides", [])
+    ]
+
+    return Manifest(
+        crimp_version=data["crimp_version"],
+        project=project,
+        components=components,
+        connections=connections,
+        wire_standards=wire_standards,
+        power_rails=power_rails,
+        bom_overrides=bom_overrides,
+    )
+
+
+def load(path: Path | str) -> Manifest:
+    """Load, validate, and parse a manifest file. Returns a typed Manifest.
+
+    Raises ManifestError on any failure.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise ManifestError(f"Manifest not found: {path}")
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ManifestError(f"Invalid JSON in manifest: {e}") from e
+
+    validate_raw(data)
+    return _parse(data)

--- a/tests/fixtures/minimal.json
+++ b/tests/fixtures/minimal.json
@@ -1,0 +1,135 @@
+{
+  "crimp_version": "0.1.0",
+  "project": {
+    "name": "Minimal Test Project",
+    "description": "Simplest possible manifest for testing."
+  },
+  "wire_standards": {
+    "signal_26awg_red": {
+      "gauge_awg": 26,
+      "color": "red"
+    },
+    "signal_26awg_black": {
+      "gauge_awg": 26,
+      "color": "black"
+    }
+  },
+  "power_rails": {
+    "3v3": {
+      "voltage_nominal": 3.3,
+      "source_component": "pico",
+      "max_current_a": 0.3
+    }
+  },
+  "components": {
+    "pico": {
+      "name": "Raspberry Pi Pico",
+      "type": "mcu",
+      "description": "RP2040 microcontroller board",
+      "voltage_logic": 3.3,
+      "pins": {
+        "GP4": {
+          "function": "I2C0 SDA",
+          "signal_type": "i2c_sda",
+          "direction": "bidir",
+          "physical_label": "GP4"
+        },
+        "3V3_OUT": {
+          "function": "3.3V power output",
+          "signal_type": "power",
+          "direction": "power",
+          "physical_label": "3V3 OUT"
+        },
+        "GND": {
+          "function": "Ground",
+          "signal_type": "ground",
+          "direction": "power",
+          "physical_label": "GND"
+        }
+      }
+    },
+    "encoder1": {
+      "name": "AS5600 Magnetic Encoder",
+      "type": "sensor",
+      "description": "12-bit magnetic rotary position sensor",
+      "voltage_logic": 3.3,
+      "connector": {
+        "type": "JST-PH-4",
+        "position": "component_side",
+        "pin_order": ["VCC", "GND", "SDA", "SCL"]
+      },
+      "pins": {
+        "SDA": {
+          "function": "I2C data",
+          "signal_type": "i2c_sda",
+          "direction": "bidir"
+        },
+        "VCC": {
+          "function": "3.3V power in",
+          "signal_type": "power",
+          "direction": "in"
+        },
+        "GND": {
+          "function": "Ground",
+          "signal_type": "ground",
+          "direction": "power"
+        }
+      }
+    }
+  },
+  "connections": [
+    {
+      "id": "enc1_vcc",
+      "label": "ENC1_VCC",
+      "from": { "component": "pico", "pin": "3V3_OUT" },
+      "to":   { "component": "encoder1", "pin": "VCC" },
+      "wire": { "ref": "signal_26awg_red" },
+      "assembly_order": 1,
+      "commissioning": {
+        "test_method": "voltage",
+        "expected_value": 3.3,
+        "tolerance": 0.1,
+        "instrument": "multimeter",
+        "notes": "Measure at encoder VCC pad. Expect 3.3V ± 0.1V."
+      }
+    },
+    {
+      "id": "enc1_gnd",
+      "label": "ENC1_GND",
+      "from": { "component": "pico", "pin": "GND" },
+      "to":   { "component": "encoder1", "pin": "GND" },
+      "wire": { "ref": "signal_26awg_black" },
+      "assembly_order": 2,
+      "commissioning": {
+        "test_method": "continuity",
+        "instrument": "multimeter"
+      }
+    },
+    {
+      "id": "enc1_sda",
+      "label": "ENC1_SDA",
+      "from": { "component": "pico", "pin": "GP4" },
+      "to":   { "component": "encoder1", "pin": "SDA" },
+      "wire": { "gauge_awg": 26, "color": "blue" },
+      "assembly_order": 3,
+      "commissioning": {
+        "test_method": "i2c_scan",
+        "expected_value": "0x36",
+        "instrument": "software",
+        "notes": "Scan I2C0 bus, expect AS5600 at address 0x36."
+      }
+    }
+  ],
+  "bom_overrides": [
+    {
+      "description": "4.7kΩ resistor (I2C0 SDA pull-up)",
+      "qty": 1,
+      "unit": "ea"
+    },
+    {
+      "description": "4.7kΩ resistor (I2C0 SCL pull-up)",
+      "qty": 1,
+      "unit": "ea"
+    }
+  ]
+}

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,155 @@
+"""Tests for manifest loading and validation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from crimp.manifest import (
+    Connection,
+    Manifest,
+    ManifestError,
+    load,
+    validate_raw,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MINIMAL = FIXTURES / "minimal.json"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def minimal_data() -> dict:
+    return json.loads(MINIMAL.read_text())
+
+
+# ---------------------------------------------------------------------------
+# validate_raw
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRaw:
+    def test_valid_minimal_passes(self):
+        validate_raw(minimal_data())
+
+    def test_missing_required_field_raises(self):
+        data = minimal_data()
+        del data["project"]
+        with pytest.raises(ManifestError, match="validation failed"):
+            validate_raw(data)
+
+    def test_invalid_component_type_raises(self):
+        data = minimal_data()
+        data["components"]["pico"]["type"] = "not_a_valid_type"
+        with pytest.raises(ManifestError, match="validation failed"):
+            validate_raw(data)
+
+    def test_invalid_signal_type_raises(self):
+        data = minimal_data()
+        data["components"]["pico"]["pins"]["GP4"]["signal_type"] = "banana"
+        with pytest.raises(ManifestError, match="validation failed"):
+            validate_raw(data)
+
+    def test_connection_missing_id_raises(self):
+        data = minimal_data()
+        del data["connections"][0]["id"]
+        with pytest.raises(ManifestError, match="validation failed"):
+            validate_raw(data)
+
+
+# ---------------------------------------------------------------------------
+# load
+# ---------------------------------------------------------------------------
+
+
+class TestLoad:
+    def test_load_returns_manifest(self):
+        m = load(MINIMAL)
+        assert isinstance(m, Manifest)
+
+    def test_project_fields(self):
+        m = load(MINIMAL)
+        assert m.project.name == "Minimal Test Project"
+        assert m.project.description == "Simplest possible manifest for testing."
+
+    def test_components_parsed(self):
+        m = load(MINIMAL)
+        assert "pico" in m.components
+        assert "encoder1" in m.components
+        assert m.components["pico"].name == "Raspberry Pi Pico"
+        assert m.components["pico"].type == "mcu"
+        assert m.components["pico"].voltage_logic == 3.3
+
+    def test_pins_parsed(self):
+        m = load(MINIMAL)
+        pins = m.components["pico"].pins
+        assert "GP4" in pins
+        assert pins["GP4"].signal_type == "i2c_sda"
+        assert pins["GP4"].direction == "bidir"
+
+    def test_connector_parsed(self):
+        m = load(MINIMAL)
+        conn = m.components["encoder1"].connector
+        assert conn is not None
+        assert conn.type == "JST-PH-4"
+        assert conn.position == "component_side"
+        assert conn.pin_order == ["VCC", "GND", "SDA", "SCL"]
+
+    def test_connections_parsed_and_sorted(self):
+        m = load(MINIMAL)
+        assert len(m.connections) == 3
+        orders = [c.assembly_order for c in m.connections]
+        assert orders == sorted(orders)
+
+    def test_connection_fields(self):
+        m = load(MINIMAL)
+        enc1_sda = next(c for c in m.connections if c.id == "enc1_sda")
+        assert enc1_sda.label == "ENC1_SDA"
+        assert enc1_sda.from_.component == "pico"
+        assert enc1_sda.from_.pin == "GP4"
+        assert enc1_sda.to.component == "encoder1"
+        assert enc1_sda.to.pin == "SDA"
+        assert enc1_sda.wire.gauge_awg == 26
+        assert enc1_sda.wire.color == "blue"
+
+    def test_wire_standard_ref_resolves(self):
+        m = load(MINIMAL)
+        enc1_vcc = next(c for c in m.connections if c.id == "enc1_vcc")
+        assert enc1_vcc.wire.color == "red"
+        assert enc1_vcc.wire.gauge_awg == 26
+
+    def test_commissioning_parsed(self):
+        m = load(MINIMAL)
+        enc1_vcc = next(c for c in m.connections if c.id == "enc1_vcc")
+        assert enc1_vcc.commissioning.test_method == "voltage"
+        assert enc1_vcc.commissioning.expected_value == 3.3
+        assert enc1_vcc.commissioning.instrument == "multimeter"
+
+    def test_wire_standards_parsed(self):
+        m = load(MINIMAL)
+        assert "signal_26awg_red" in m.wire_standards
+        assert m.wire_standards["signal_26awg_red"].color == "red"
+
+    def test_power_rails_parsed(self):
+        m = load(MINIMAL)
+        assert "3v3" in m.power_rails
+        assert m.power_rails["3v3"].voltage_nominal == 3.3
+
+    def test_bom_overrides_parsed(self):
+        m = load(MINIMAL)
+        assert len(m.bom_overrides) == 2
+        assert m.bom_overrides[0].description == "4.7kΩ resistor (I2C0 SDA pull-up)"
+        assert m.bom_overrides[0].qty == 1
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(ManifestError, match="not found"):
+            load(tmp_path / "nonexistent.json")
+
+    def test_invalid_json_raises(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ this is not json }")
+        with pytest.raises(ManifestError, match="Invalid JSON"):
+            load(bad)


### PR DESCRIPTION
## Summary
- Implements `manifest.py` with `load()`, `validate_raw()`, and a full typed dataclass model
- Validates manifests against `schema/manifest.schema.json` with clear human-readable error messages
- Resolves `wire_standards` refs inline, sorts connections by `assembly_order`
- Wires up `crimp validate` CLI command with rich table output
- Adds `tests/fixtures/minimal.json` as the base test fixture (Pico → AS5600 encoder)
- 19 tests, all passing

## Test plan
- [ ] `crimp validate tests/fixtures/minimal.json` shows valid output
- [ ] `crimp validate` on a broken manifest shows clear error
- [ ] `python3 -m pytest tests/test_manifest.py -v` — 19 passed

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)